### PR TITLE
config fixes finally :)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,6 @@
         <javafaker.version>1.0.2</javafaker.version>
         <projectlombok.version>1.18.24</projectlombok.version>
 
-        <name>${project.name}</name>
-        <targetBrowser>chrome</targetBrowser>
-
     </properties>
 
     <dependencies>
@@ -61,35 +58,5 @@
         </dependency>
 
     </dependencies>
-
-    <build>
-
-<!--        <resources>-->
-<!--            <resource>-->
-<!--                <directory>src/main/resources</directory>-->
-<!--                <filtering>true</filtering>-->
-<!--            </resource>-->
-<!--        </resources>-->
-
-        <plugins>
-<!--            <plugin>-->
-<!--                <groupId>org.codehaus.mojo</groupId>-->
-<!--                <artifactId>properties-maven-plugin</artifactId>-->
-<!--                <version>1.0.0</version>-->
-<!--                <executions>-->
-<!--                    <execution>-->
-<!--                        <phase>generate-resources</phase>-->
-<!--                        <goals>-->
-<!--                            <goal>write-project-properties</goal>-->
-<!--                        </goals>-->
-<!--                        <configuration>-->
-<!--                            <outputFile>${project.build.outputDirectory}/config.properties</outputFile>-->
-<!--                        </configuration>-->
-<!--                    </execution>-->
-<!--                </executions>-->
-<!--            </plugin>-->
-        </plugins>
-
-    </build>
 
 </project>

--- a/src/test/java/BaseTest.java
+++ b/src/test/java/BaseTest.java
@@ -25,7 +25,10 @@ public class BaseTest {
     @BeforeClass
     public void setupSuite() {
         PropertiesReader propertiesReader = PropertiesReader.getInstance();
-        targetBrowser = propertiesReader.getProperty("targetBrowser");
+        System.out.print(propertiesReader);
+        targetBrowser = System.getProperty("targetBrowser", propertiesReader.getProperty("targetBrowser"));
+        System.out.print("browser\n");
+        System.out.print(targetBrowser);
     }
 
     @BeforeMethod


### PR DESCRIPTION
if system property **targetBrowser** provided as a command line arg to maven then it will be used
otherwise .properties property would be used

example

config.properties file
`targetBrowser=chrome
`

maven command:
`mvn clean test -DtargetBrowser=edge` => edge driver would be initialized, overrides the chrome defined in config.properties

maven command:
`mvn clean test` => chrome driver would be initialized

maven command:
`mvn clean test -DtargetBrowser=FILIP` => chrome driver would be initialized because of the switch/default 